### PR TITLE
Simplify load and hydrate in next.load.ts

### DIFF
--- a/example/app/page.tsx
+++ b/example/app/page.tsx
@@ -2,5 +2,5 @@ import { consume } from 'next-load';
 
 export default function Page() {
   const data = consume<any>();
-  return <h1>{data?.user?.username}</h1>;
+  return <h1>{JSON.stringify(data)}</h1>;
 }

--- a/example/app/page.tsx
+++ b/example/app/page.tsx
@@ -1,19 +1,6 @@
 import { consume } from 'next-load';
 
-type User = {
-  displayName: string;
-  username: string;
-}
-
-export async function load() {
-  const user: User = await Promise.resolve({
-    displayName: 'Works',
-    username: 'next-load-example'
-  });
-  return user.displayName;
-}
-
 export default function Page() {
-  const text = consume<string>();
-  return <h1>{text}</h1>;
+  const data = consume<any>();
+  return <h1>{data?.user?.username}</h1>;
 }

--- a/example/app/page.tsx
+++ b/example/app/page.tsx
@@ -1,7 +1,16 @@
 import { consume } from 'next-load';
 
-export function load() {
-  return 'WORKS😊';
+type User = {
+  displayName: string;
+  username: string;
+}
+
+export async function load() {
+  const user: User = await Promise.resolve({
+    displayName: 'Works',
+    username: 'next-load-example'
+  });
+  return user.displayName;
 }
 
 export default function Page() {

--- a/example/app/types.ts
+++ b/example/app/types.ts
@@ -1,0 +1,9 @@
+export type User = {
+  displayName?: string
+  username: string
+}
+
+export type Post = {
+  title: string
+  content: string
+}

--- a/example/next.load.ts
+++ b/example/next.load.ts
@@ -1,0 +1,24 @@
+export default {
+  load: {
+    '*': getUser,
+  },
+  hydrate: {
+    '*': getUserName,
+  }
+}
+
+type User = {
+  displayName: string
+  username: string
+}
+
+async function getUser() {
+  return {
+    displayName: 'Works in next.load.ts',
+    username: 'next-load-example'
+  }
+}
+
+async function getUserName(user: User) {
+  return user.displayName
+}

--- a/example/next.load.ts
+++ b/example/next.load.ts
@@ -1,6 +1,8 @@
+import { Post, User } from "./app/types"
+
 export default {
   user: {
-    pages: ['/', '/about', '/contact', '/blog/[slug]'],
+    pages: ['/', '/about', '/contact', '/blog/[slug]', new RegExp('^/example')],
     load: getUser,
     hydrate: mapUserDataForClientSide,
   },
@@ -8,16 +10,6 @@ export default {
     pages: ['/blog/[slug]', '/blog/[slug]/comments'],
     load: getPosts,
   },
-}
-
-type User = {
-  displayName?: string
-  username: string
-}
-
-type Post = {
-  title: string
-  content: string
 }
 
 async function getUser(): Promise<User> {

--- a/example/next.load.ts
+++ b/example/next.load.ts
@@ -16,8 +16,8 @@ async function getUser(): Promise<User> {
   return { username: 'aralroca', displayName: 'Aral Roca' }
 }
 
-function mapUserDataForClientSide(user: User): User {
-  return { username: user.username }
+function mapUserDataForClientSide(user: User, pathname: string): User {
+  if (pathname.startsWith('/blog')) return { username: user.username }
 }
 
 async function getPosts(): Promise<Post[]> {

--- a/example/next.load.ts
+++ b/example/next.load.ts
@@ -1,24 +1,33 @@
 export default {
-  load: {
-    '*': getUser,
+  user: {
+    pages: ['/', '/about', '/contact', '/blog/[slug]'],
+    load: getUser,
+    hydrate: mapUserDataForClientSide,
   },
-  hydrate: {
-    '*': getUserName,
-  }
+  posts: {
+    pages: ['/blog/[slug]', '/blog/[slug]/comments'],
+    load: getPosts,
+  },
 }
 
 type User = {
-  displayName: string
+  displayName?: string
   username: string
 }
 
-async function getUser() {
-  return {
-    displayName: 'Works in next.load.ts',
-    username: 'next-load-example'
-  }
+type Post = {
+  title: string
+  content: string
 }
 
-async function getUserName(user: User) {
-  return user.displayName
+async function getUser(): Promise<User> {
+  return { username: 'aralroca', displayName: 'Aral Roca' }
+}
+
+function mapUserDataForClientSide(user: User): User {
+  return { username: user.username }
+}
+
+async function getPosts(): Promise<Post[]> {
+  return [{ title: 'My first post', content: 'Hello world!' }]
 }

--- a/packages/next-load-plugin/__tests__/transformer.test.tsx
+++ b/packages/next-load-plugin/__tests__/transformer.test.tsx
@@ -139,12 +139,10 @@ describe('transformer', () => {
       expect(div.textContent).toBe('Page: LOAD WORKS')
     })
     it('SHOULD receive the page props as params to load better the data in a SERVER /page', async () => {
-      type PageProps = { text: string }
-
       await applyConfig({
         data: {
           pages: ['/'],
-          load: async (pageProps: PageProps) => ({ text: 'LOAD WORKS IN ' + pageProps.text.toUpperCase() })
+          load: async ({ pageProps }: any) => ({ text: 'LOAD WORKS IN ' + pageProps.text.toUpperCase() })
         }
       })
 
@@ -154,9 +152,9 @@ describe('transformer', () => {
 
         type DataType = { text: string };
 
-        export default function Page(pageProps) {
+        export default function Page(props) {
           const { data } = consume<DataType>();
-          return <div data-testid="test-id">{pageProps.text}: {data.text}</div>; 
+          return <div data-testid="test-id">{props.text}: {data.text}</div>; 
         }
       `)
       const options = { pageNoExt: '/page', loaders: ['/'], ...insideAppDir }
@@ -171,7 +169,7 @@ describe('transformer', () => {
       await applyConfig({
         data: {
           pages: ['/about'],
-          load: async (pageProps: any, pathname: string) => {
+          load: async ({ pageProps }: any, pathname: string) => {
             mockLoad(pageProps, pathname)
             return { text: `LOAD WORKS IN ${pathname}` }
           },
@@ -314,7 +312,7 @@ describe('transformer', () => {
       await applyConfig({
         data: {
           pages: ['/about'],
-          load: async (pageProps: any, pathname: string) => {
+          load: async ({ pageProps }: any, pathname: string) => {
             mockLoad(pageProps, pathname)
             return { text: `LOAD WORKS IN ${pathname}` }
           },
@@ -343,7 +341,7 @@ describe('transformer', () => {
       await applyConfig({
         data: {
           pages: ['/'],
-          load: async (pageProps: any) => ({ text: 'LOAD WORKS IN ' + pageProps.text.toUpperCase() })
+          load: async ({ pageProps }: any) => ({ text: 'LOAD WORKS IN ' + pageProps.text.toUpperCase() })
         }
       })
       const pagePkg = parseCode('jsx', `
@@ -562,7 +560,7 @@ describe('transformer', () => {
       await applyConfig({
         data: {
           pages: ['/about'],
-          load: async (pageProps: any, pathname: string) => {
+          load: async ({ pageProps }: any, pathname: string) => {
             mockLoad(pageProps, pathname)
             return { text: `LOAD WORKS IN ${pathname}` }
           },

--- a/packages/next-load-plugin/__tests__/utils.test.ts
+++ b/packages/next-load-plugin/__tests__/utils.test.ts
@@ -1,0 +1,109 @@
+import fs from 'fs'
+import { getLoadersAndHydratorsLists } from "../src/utils";
+
+describe('utils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getLoadersAndHydratorsLists', () => {
+    it('should work with export default', async () => {
+      const dir = '/path/to/directory';
+      const code = `
+        import some from 'some';
+
+        export default {
+          load: {
+            '*': () => {},
+            '/some/path': async () => 9,
+          },
+          hydrate: {
+            '*': () => {},
+            '/some/another/path': async () => [1, 2, 3],
+          },
+        }
+      `;
+      const tempFile = `${dir}/next.load.js` as any;
+      jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([tempFile]);
+      jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(code);
+      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir);
+      expect(loaders).toEqual(['*', '/some/path']);
+      expect(hydraters).toEqual(['*', '/some/another/path']);
+    });
+    it('should work with module.exports', async () => {
+      const dir = '/path/to/directory';
+      const code = `
+        module.exports = {
+          load: {
+            '*': () => {},
+            '/some/path': async () => 9,
+          },
+          hydrate: {
+            '*': () => {},
+            '/some/another/path': async () => [1, 2, 3],
+          },
+        }
+      `;
+      const tempFile = `${dir}/next.load.js` as any;
+      jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([tempFile]);
+      jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(code);
+      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir);
+      expect(loaders).toEqual(['*', '/some/path']);
+      expect(hydraters).toEqual(['*', '/some/another/path']);
+    });
+    it('should work without loaders', async () => {
+      const dir = '/path/to/directory';
+      const code = `
+        export default {
+          hydrate: {
+            '*': () => {},
+            '/some/another/path': async () => [1, 2, 3],
+          },
+        }
+      `;
+      const tempFile = `${dir}/next.load.js` as any;
+      jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([tempFile]);
+      jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(code);
+      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir);
+      expect(loaders).toEqual([]);
+      expect(hydraters).toEqual(['*', '/some/another/path']);
+    });
+    it('should work without hydraters', async () => {
+      const dir = '/path/to/directory';
+      const code = `
+        export default {
+          load: {
+            '*': () => {},
+            '/some/path': async () => [1, 2, 3],
+          },
+        }
+      `;
+      const tempFile = `${dir}/next.load.js` as any;
+      jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([tempFile]);
+      jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(code);
+      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir);
+      expect(loaders).toEqual(['*', '/some/path']);
+      expect(hydraters).toEqual([]);
+    });
+    it('should work without loaders nor hydraters', async () => {
+      const dir = '/path/to/directory';
+      const code = 'export default {}';
+      const tempFile = `${dir}/next.load.js` as any;
+      jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([tempFile]);
+      jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(code);
+      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir);
+      expect(loaders).toEqual([]);
+      expect(hydraters).toEqual([]);
+    });
+    it('should work with a different export default', async () => {
+      const dir = '/path/to/directory';
+      const code = 'export default ["another", "export"]]';
+      const tempFile = `${dir}/next.load.js` as any;
+      jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([tempFile]);
+      jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(code);
+      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir);
+      expect(loaders).toEqual([]);
+      expect(hydraters).toEqual([]);
+    });
+  })
+});

--- a/packages/next-load-plugin/__tests__/utils.test.ts
+++ b/packages/next-load-plugin/__tests__/utils.test.ts
@@ -1,10 +1,25 @@
 import fs from 'fs'
-import { getLoadersAndHydratorsLists } from "../src/utils";
+import { getLoadersAndHydratorsLists, isPageOfTheList } from "../src/utils";
 
 describe('utils', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
+
+  describe('isPageOfTheList', () => {
+    it('should return true with /about string', () => {
+      const result = isPageOfTheList('/about', ['/about', '/contact', '/blog/[slug]']);
+      expect(result).toBeTruthy();
+    })
+    it('should return false if the /about string is not in the list', () => {
+      const result = isPageOfTheList('/about', ['/about', '/contact', '/blog/[slug]']);
+      expect(result).toBeTruthy();
+    })
+    it('should work with regex in the list', () => {
+      const result = isPageOfTheList('/about', ['/contact', '/blog/[slug]', /about/g]);
+      expect(result).toBeTruthy();
+    })
+  })
 
   describe('getLoadersAndHydratorsLists', () => {
     it('should work with export default', async () => {

--- a/packages/next-load-plugin/__tests__/utils.test.ts
+++ b/packages/next-load-plugin/__tests__/utils.test.ts
@@ -42,7 +42,7 @@ describe('utils', () => {
       const tempFile = `${dir}/next.load.js` as any;
       jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([tempFile]);
       jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(code);
-      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir);
+      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir, 'next.load.js');
       expect(loaders).toEqual(['/', '/about', '/contact', '/blog/[slug]', '/blog/[slug]/comments']);
       expect(hydraters).toEqual(['/', '/about', '/contact', '/blog/[slug]']);
     });
@@ -66,7 +66,7 @@ describe('utils', () => {
       const tempFile = `${dir}/next.load.js` as any;
       jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([tempFile]);
       jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(code);
-      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir);
+      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir, 'next.load.js');
       expect(loaders).toEqual(['/', '/about', '/contact', /\/example\/[a-z]+/, '/blog/[slug]', '/blog/[slug]/comments']);
       expect(hydraters).toEqual(['/', '/about', '/contact', /\/example\/[a-z]+/,]);
     });
@@ -88,7 +88,7 @@ describe('utils', () => {
       const tempFile = `${dir}/next.load.js` as any;
       jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([tempFile]);
       jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(code);
-      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir);
+      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir, 'next.load.js');
       expect(loaders).toEqual(['/', '/about', '/contact', '/blog/[slug]', '/blog/[slug]/comments']);
       expect(hydraters).toEqual(['/', '/about', '/contact', '/blog/[slug]']);
     });
@@ -112,7 +112,7 @@ describe('utils', () => {
       const tempFile = `${dir}/next.load.js` as any;
       jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([tempFile]);
       jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(code);
-      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir);
+      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir, 'next.load.js');
       expect(loaders).toEqual(['/', '/about', new RegExp('/contact/[a-z]+'), new RegExp('/example/[a-z]+'), '/blog/[slug]', '/blog/[slug]/comments']);
       expect(hydraters).toEqual(['/', '/about', new RegExp('/contact/[a-z]+'), new RegExp('/example/[a-z]+'),]);
     });
@@ -129,7 +129,7 @@ describe('utils', () => {
       const tempFile = `${dir}/next.load.js` as any;
       jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([tempFile]);
       jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(code);
-      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir);
+      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir, 'next.load.js');
       expect(loaders).toEqual([]);
       expect(hydraters).toEqual(['/', '/about', '/contact', '/blog/[slug]']);
     });
@@ -150,7 +150,7 @@ describe('utils', () => {
       const tempFile = `${dir}/next.load.js` as any;
       jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([tempFile]);
       jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(code);
-      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir);
+      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir, 'next.load.js');
       expect(loaders).toEqual(['/', '/about', '/contact', '/blog/[slug]', '/blog/[slug]/comments']);
       expect(hydraters).toEqual([]);
     });
@@ -160,7 +160,7 @@ describe('utils', () => {
       const tempFile = `${dir}/next.load.js` as any;
       jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([tempFile]);
       jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(code);
-      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir);
+      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir, 'next.load.js');
       expect(loaders).toEqual([]);
       expect(hydraters).toEqual([]);
     });
@@ -170,7 +170,7 @@ describe('utils', () => {
       const tempFile = `${dir}/next.load.js` as any;
       jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([tempFile]);
       jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(code);
-      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir);
+      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir, 'next.load.js');
       expect(loaders).toEqual([]);
       expect(hydraters).toEqual([]);
     });
@@ -180,7 +180,7 @@ describe('utils', () => {
       const tempFile = `${dir}/next.load.js` as any;
       jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([tempFile]);
       jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(code);
-      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir);
+      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir, 'next.load.js');
       expect(loaders).toEqual([]);
       expect(hydraters).toEqual([]);
     });
@@ -190,7 +190,7 @@ describe('utils', () => {
       const tempFile = `${dir}/next.load.js` as any;
       jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([tempFile]);
       jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(code);
-      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir);
+      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir, 'next.load.js');
       expect(loaders).toEqual([]);
       expect(hydraters).toEqual([]);
     });
@@ -200,7 +200,7 @@ describe('utils', () => {
       const tempFile = `${dir}/next.load.js` as any;
       jest.spyOn(fs, 'readdirSync').mockReturnValueOnce([tempFile]);
       jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(code);
-      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir);
+      const { loaders, hydraters } = getLoadersAndHydratorsLists(dir, 'next.load.js');
       expect(loaders).toEqual([]);
       expect(hydraters).toEqual([]);
     });

--- a/packages/next-load-plugin/src/index.ts
+++ b/packages/next-load-plugin/src/index.ts
@@ -4,9 +4,10 @@ import type webpack from 'webpack'
 import type { NextConfig } from 'next'
 
 import { LoaderOptions } from './types'
-import { extensionsRgx, getLoadersAndHydratorsLists } from './utils'
+import { createConfigFileIfNotExists, extensionsRgx, getLoadersAndHydratorsLists } from './utils'
 
 const possiblePageDirs = ['app', 'src/app']
+const filename = 'next.load'
 
 function nextLoadPlugin(nextConfig: NextConfig = {}): NextConfig {
   if (!nextConfig?.experimental?.appDir) return nextConfig
@@ -18,8 +19,12 @@ function nextLoadPlugin(nextConfig: NextConfig = {}): NextConfig {
     path.relative(basePath, process.env.NEXT_LOAD_PATH || '.')
   )
 
+  // Next-load config file
+  const nextLoadConfigFilename = fs.readdirSync(dir).find(file => file.startsWith(filename + '.')) || filename + '.js'
+  createConfigFileIfNotExists(dir, nextLoadConfigFilename)
+
   // Loaders & Hydrators
-  const { loaders, hydraters } = getLoadersAndHydratorsLists(dir)
+  const { loaders, hydraters } = getLoadersAndHydratorsLists(dir, nextLoadConfigFilename)
 
   // app or src/app
   const pagesInDir = possiblePageDirs.find((pageDir) =>

--- a/packages/next-load-plugin/src/index.ts
+++ b/packages/next-load-plugin/src/index.ts
@@ -20,8 +20,8 @@ function nextLoadPlugin(nextConfig: NextConfig = {}): NextConfig {
 
   // Loaders & Hydrators
   const { loaders, hydraters } = getLoadersAndHydratorsLists(dir)
-  console.log({ loaders, hydraters })
 
+  // app or src/app
   const pagesInDir = possiblePageDirs.find((pageDir) =>
     fs.existsSync(path.join(dir, pageDir))
   );
@@ -58,6 +58,8 @@ function nextLoadPlugin(nextConfig: NextConfig = {}): NextConfig {
           options: {
             basePath,
             pagesPath: path.join(pagesPath, '/'),
+            loaders,
+            hydraters,
           } as LoaderOptions,
         },
       })

--- a/packages/next-load-plugin/src/loader.ts
+++ b/packages/next-load-plugin/src/loader.ts
@@ -8,7 +8,7 @@ export default function loader(
   this: webpack.LoaderContext<LoaderOptions>,
   rawCode: string
 ) {
-  const { basePath, pagesPath } = this.getOptions()
+  const { basePath, pagesPath, hydraters, loaders } = this.getOptions()
 
   // Normalize slashes in a file path to be posix/unix-like forward slashes
   const normalizedPagesPath = pagesPath.replace(/\\/g, '/')
@@ -22,5 +22,5 @@ export default function loader(
   // "export default" on the page
   if (!defaultExport) return rawCode
 
-  return transformer(pagePkg, { pageNoExt, normalizedResourcePath, normalizedPagesPath })
+  return transformer(pagePkg, { pageNoExt, normalizedResourcePath, normalizedPagesPath, hydraters, loaders })
 }

--- a/packages/next-load-plugin/src/transformer.ts
+++ b/packages/next-load-plugin/src/transformer.ts
@@ -37,8 +37,8 @@ export default function transformer(pagePkg: ParsedFilePkg, { pageNoExt = '/', n
   // Removes the export default from the page
   // and tells under what name we can get the old export
   const pageVariableName = interceptExport(pagePkg, 'default', `__Next_Load__Page__${hash}__`)
-  const hasLoad = isPageOfTheList(pageNoExt, loaders)
-  const hasHydrate = isPageOfTheList(pageNoExt, hydraters)
+  const hasLoad = isPageOfTheList(pathname, loaders)
+  const hasHydrate = isPageOfTheList(pathname, hydraters)
   const pageWithoutLoadExport = isPage && !hasLoad
 
   // The "hydrate export" function is exclusively accessible within a server page
@@ -104,7 +104,7 @@ function transformClientPage({ code, hash, pageVariableName, pathname, hasLoad }
     import { useSearchParams as __useSearchParams } from 'next/navigation'
     import * as __react from 'react'
     import __next_load_config from '@next-load-root/next.load'
-    import { __nl_load, __nl_hydrate } from 'next-load'
+    import { __nl_load } from 'next-load'
 
     ${clientCode}
 
@@ -120,7 +120,7 @@ function transformClientPage({ code, hash, pageVariableName, pathname, hasLoad }
         ${load}.then(_data => {
           window.__NEXT_LOAD__ = { hydrate: _data, page }
           forceUpdate()
-        })
+        }).catch(err => console.log(err))
       }, [])
 
       if (isServer || !window.__NEXT_LOAD__) return null

--- a/packages/next-load-plugin/src/transformer.ts
+++ b/packages/next-load-plugin/src/transformer.ts
@@ -1,5 +1,5 @@
 import { ParsedFilePkg } from "./types";
-import { interceptExport, getNamedExport, removeCommentsFromCode, colorRed, colorOrange } from "./utils";
+import { interceptExport, removeCommentsFromCode, colorRed, colorOrange, isPageOfTheList } from "./utils";
 
 const clientLine = ['"use client"', "'use client'"]
 
@@ -8,13 +8,21 @@ type TransformParams = {
   hash: string,
   pageVariableName: string,
   pathname?: string,
-  load?: string,
-  hydrate?: string,
+  hasLoad?: boolean,
+  hasHydrate?: boolean,
+}
+
+type TransformOptions = {
+  pageNoExt?: string,
+  normalizedResourcePath?: string,
+  normalizedPagesPath?: string,
+  hydraters?: (string | RegExp)[],
+  loaders?: (string | RegExp)[],
 }
 
 const moreHydrateInfo = 'For more information, please refer to the documentation provided at https://github.com/aralroca/next-load#hydrate.'
 
-export default function transformer(pagePkg: ParsedFilePkg, { pageNoExt = '/', normalizedResourcePath = '', normalizedPagesPath = '' } = {}) {
+export default function transformer(pagePkg: ParsedFilePkg, { pageNoExt = '/', normalizedResourcePath = '', normalizedPagesPath = '', hydraters = [], loaders = [] }: TransformOptions) {
   let code = pagePkg.getCode()
   const codeWithoutComments = removeCommentsFromCode(code).trim()
   const isClientCode = clientLine.some(line => codeWithoutComments.startsWith(line))
@@ -29,20 +37,17 @@ export default function transformer(pagePkg: ParsedFilePkg, { pageNoExt = '/', n
   // Removes the export default from the page
   // and tells under what name we can get the old export
   const pageVariableName = interceptExport(pagePkg, 'default', `__Next_Load__Page__${hash}__`)
-  const loadExport = getNamedExport(pagePkg, 'load')
-  const hydrateExport = getNamedExport(pagePkg, 'hydrate')
-  const pageWithoutLoadExport = isPage && !loadExport
-  const load = `Promise.resolve(${loadExport ? 'load(props)' : ''})`
-  let hydrate = `Promise.resolve(${hydrateExport ? 'hydrate(_data)' : '_data'})`
+  const hasLoad = isPageOfTheList(pageNoExt, loaders)
+  const hasHydrate = isPageOfTheList(pageNoExt, hydraters)
+  const pageWithoutLoadExport = isPage && !hasLoad
 
   // The "hydrate export" function is exclusively accessible within a server page
-  if (isPage && isClientCode && hydrateExport) {
+  if (isPage && isClientCode && hasHydrate) {
     console.log(colorRed('[next-load] ERROR '), colorOrange(`The "hydrate export" function is exclusively accessible within a server page. To achieve similar functionality, utilize the "load export" function. ${moreHydrateInfo}`))
-    hydrate = `Promise.resolve(_data)`
   }
 
   // The function "hydrate export" can only be accessed through the use of "load export"
-  if (isPage && !isClientCode && !loadExport && hydrateExport) {
+  if (isPage && !isClientCode && !hasLoad && hasHydrate) {
     console.log(colorRed('[next-load] ERROR '), colorOrange(`The function "hydrate export" can only be accessed through the use of "load export". ${moreHydrateInfo}`))
   }
 
@@ -53,13 +58,18 @@ export default function transformer(pagePkg: ParsedFilePkg, { pageNoExt = '/', n
   code = pagePkg.getCode()
 
   if (isClientCode && !isPage) return transformClientComponent({ code, hash, pageVariableName })
-  if (isClientCode && isPage) return transformClientPage({ code, hash, pageVariableName, pathname, load, hydrate })
-  return transformServerPage({ code, hash, pageVariableName, pathname, load, hydrate })
+  if (isClientCode && isPage) return transformClientPage({ code, hash, pageVariableName, pathname, hasLoad })
+  return transformServerPage({ code, hash, pageVariableName, pathname, hasLoad, hasHydrate })
 }
 
-function transformServerPage({ code, hash, pageVariableName, pathname, load, hydrate }: TransformParams) {
+function transformServerPage({ code, hash, pageVariableName, pathname, hasLoad, hasHydrate }: TransformParams) {
+  const load = `Promise.resolve(${hasLoad ? `__nl_load(props, '${pathname}', __next_load_config)` : ''})`
+  const hydrate = `Promise.resolve(${hasHydrate ? `__nl_hydrate(_data, '${pathname}', __next_load_config)` : '_data'})`
+
   return `
   import * as __react from 'react'
+  import __next_load_config from '@next-load-root/next.load'
+  import { __nl_load, __nl_hydrate } from 'next-load'
 
   ${code}
 
@@ -82,7 +92,8 @@ function transformServerPage({ code, hash, pageVariableName, pathname, load, hyd
 `
 }
 
-function transformClientPage({ code, hash, pageVariableName, pathname, load }: TransformParams) {
+function transformClientPage({ code, hash, pageVariableName, pathname, hasLoad }: TransformParams) {
+  const load = `Promise.resolve(${hasLoad ? `__nl_load(props, '${pathname}', __next_load_config)` : ''})`
   let clientCode = code
   const topLine = clientLine[0]
 
@@ -92,6 +103,8 @@ function transformClientPage({ code, hash, pageVariableName, pathname, load }: T
   return `${topLine}
     import { useSearchParams as __useSearchParams } from 'next/navigation'
     import * as __react from 'react'
+    import __next_load_config from '@next-load-root/next.load'
+    import { __nl_load, __nl_hydrate } from 'next-load'
 
     ${clientCode}
 

--- a/packages/next-load-plugin/src/types.ts
+++ b/packages/next-load-plugin/src/types.ts
@@ -3,6 +3,8 @@ import type ts from 'typescript'
 export interface LoaderOptions {
   basePath: string
   pagesPath: string
+  loaders: (string | RegExp)[]
+  hydraters: (string | RegExp)[]
 }
 
 export type Transformer = (

--- a/packages/next-load-plugin/src/utils.ts
+++ b/packages/next-load-plugin/src/utils.ts
@@ -547,3 +547,10 @@ function removeQuotes(str: string) {
 function uniqueArray<T>(arr: T[]) {
   return Array.from(new Set(arr))
 }
+
+export function isPageOfTheList(page: string, list: (string | RegExp)[] = []) {
+  return list.some((item) => {
+    if (typeof item === 'string') return item === page
+    return item.test(page)
+  })
+}

--- a/packages/next-load-plugin/src/utils.ts
+++ b/packages/next-load-plugin/src/utils.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import ts from 'typescript'
+import path from 'path'
 import { ParsedFilePkg, Transformer } from './types'
 
 export const extensionsRgx = /\.(tsx|ts|js|cjs|mjs|jsx)$/
@@ -477,11 +478,9 @@ export function getCommonJSModuleExports(filePkg: ParsedFilePkg) {
   return exports
 }
 
-export function getLoadersAndHydratorsLists(dir: string) {
-  const filename = 'next.load'
+export function getLoadersAndHydratorsLists(dir: string, nextLoadConfigFilename: string) {
   const loaders: string[] = [];
   const hydraters: string[] = [];
-  const nextLoadConfigFilename = fs.readdirSync(dir).find(file => file.startsWith(filename + '.')) || filename + '.js'
   const nextLoadConfigPkg = parseFile(dir, nextLoadConfigFilename)
   const nextLoadConfigExport = getDefaultExport(nextLoadConfigPkg)
 
@@ -553,4 +552,14 @@ export function isPageOfTheList(page: string, list: (string | RegExp)[] = []) {
     if (typeof item === 'string') return item === page
     return item.test(page)
   })
+}
+
+export function createConfigFileIfNotExists(dir: string, filename: string) {
+  if (fs.existsSync(path.join(dir, filename))) return
+  fs.writeFileSync(path.join(dir, filename), `export default { 
+  example: {
+    pages: ['/example', new RegExp('^/')],
+    load: async () => 'Modify the next.load.(js|ts) file to change the pages data',
+  }
+}`)
 }

--- a/packages/next-load-plugin/src/utils.ts
+++ b/packages/next-load-plugin/src/utils.ts
@@ -521,8 +521,13 @@ function getPagesFromNode(node: ts.Node) {
     const text = removeQuotes(n.name.getText())
     if (text === 'pages') {
       ts.forEachChild(n.initializer, (n) => {
-        if (!ts.isStringLiteral(n)) return
-        pages.push(n.text)
+        const innerText = n.getText().trim()
+        if (innerText === 'load') load = true
+        if (innerText === 'hydrate') hydrate = true
+        if (ts.isStringLiteral(n)) pages.push(n.text)
+        else if (n.kind === ts.SyntaxKind.NewExpression || n.kind === ts.SyntaxKind.RegularExpressionLiteral) {
+          pages.push(eval(innerText))
+        }
       })
     }
     if (text === 'load') load = true

--- a/packages/next-load/index.test.tsx
+++ b/packages/next-load/index.test.tsx
@@ -8,11 +8,12 @@ type User = {
 }
 
 describe("next-load", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   describe("consume", () => {
+    beforeEach(() => {
+      delete globalThis.__NEXT_LOAD__
+      jest.clearAllMocks();
+    });
+
     it("should work", () => {
       console.warn = jest.fn();
       globalThis.__NEXT_LOAD__ = { hydrate: "next-load" };
@@ -36,21 +37,9 @@ describe("next-load", () => {
   });
 
   describe("_useHydrate", () => {
-    it("should work", async () => {
-      const Parent = ({ children }: { children: React.ReactNode }) => {
-        return <div id="__NEXT_LOAD_DATA__" data-hydrate="next-load" data-page="/test">{children}</div>
-      };
-
-      const Component = () => {
-        _useHydrate();
-        return <>{'RESULT: ' + window.__NEXT_LOAD__.hydrate}</>;
-      };
-
-      render(<Parent><Component /></Parent>)
-
-      const text = await screen.findByText("RESULT: next-load");
-
-      expect(text.id).toEqual('__NEXT_LOAD_DATA__');
+    beforeEach(() => {
+      delete window.__NEXT_LOAD__
+      jest.clearAllMocks();
     });
     it("should work with an object", async () => {
       const Parent = ({ children }: { children: React.ReactNode }) => {
@@ -59,7 +48,7 @@ describe("next-load", () => {
 
       const Component = () => {
         _useHydrate();
-        return <>{'RESULT: ' + window.__NEXT_LOAD__.hydrate.data.test}</>;
+        return <>{'RESULT: ' + window.__NEXT_LOAD__.hydrate?.data?.text}</>;
       };
 
       render(<Parent><Component /></Parent>)
@@ -71,6 +60,11 @@ describe("next-load", () => {
   });
 
   describe("__nl_load", () => {
+    beforeEach(() => {
+      delete globalThis.__NEXT_LOAD__
+      jest.clearAllMocks();
+    });
+
     it("should work", async () => {
       const config = {
         data: {

--- a/packages/next-load/index.test.tsx
+++ b/packages/next-load/index.test.tsx
@@ -52,6 +52,22 @@ describe("next-load", () => {
 
       expect(text.id).toEqual('__NEXT_LOAD_DATA__');
     });
+    it("should work with an object", async () => {
+      const Parent = ({ children }: { children: React.ReactNode }) => {
+        return <div id="__NEXT_LOAD_DATA__" data-hydrate={JSON.stringify({ data: { text: 'test' } })} data-page="/test">{children}</div>
+      };
+
+      const Component = () => {
+        _useHydrate();
+        return <>{'RESULT: ' + window.__NEXT_LOAD__.hydrate.data.test}</>;
+      };
+
+      render(<Parent><Component /></Parent>)
+
+      const text = await screen.findByText("RESULT: test");
+
+      expect(text.id).toEqual('__NEXT_LOAD_DATA__');
+    });
   });
 
   describe("__nl_load", () => {

--- a/packages/next-load/index.test.tsx
+++ b/packages/next-load/index.test.tsx
@@ -1,6 +1,11 @@
 import React from 'react'
-import { consume, _useHydrate } from "./index";
+import { consume, _useHydrate, __nl_load, __nl_hydrate } from "./index";
 import { render, screen } from "@testing-library/react";
+
+type User = {
+  username: string;
+  displayName?: string;
+}
 
 describe("next-load", () => {
   beforeEach(() => {
@@ -46,6 +51,52 @@ describe("next-load", () => {
       const text = await screen.findByText("RESULT: next-load");
 
       expect(text.id).toEqual('__NEXT_LOAD_DATA__');
+    });
+  });
+
+  describe("__nl_load", () => {
+    it("should work", async () => {
+      const config = {
+        data: {
+          pages: ['/about'],
+          load: async () => 'works'
+        },
+        user: {
+          pages: ['/about'],
+          load: () => ({ username: 'Aral' })
+        },
+        empty: {},
+        error: {
+          pages: ['/error'],
+          load: () => ({ error: '404' })
+        }
+      }
+      const data = await __nl_load(undefined, '/about', config);
+      expect(data).toEqual({ data: 'works', user: { username: 'Aral' } });
+    });
+  });
+
+  describe("__nl_hydrate", () => {
+    it("should work", async () => {
+      const config = {
+        data: {
+          pages: ['/about'],
+          load: async () => 'works'
+        },
+        user: {
+          pages: ['/about'],
+          load: () => ({ username: 'aralroca', displayName: 'Aral Roca' } as User),
+          hydrate: (user: User) => ({ username: user.username.toUpperCase() })
+        },
+        empty: {},
+        error: {
+          pages: ['/error'],
+          load: () => ({ error: '404' })
+        }
+      }
+      const loadData = await __nl_load(undefined, '/about', config);
+      const data = await __nl_hydrate(loadData, '/about', config);
+      expect(data).toEqual({ data: 'works', user: { username: 'ARALROCA' } });
     });
   });
 });

--- a/packages/next-load/index.ts
+++ b/packages/next-load/index.ts
@@ -20,17 +20,17 @@ export function _useHydrate() {
 
   if (isClient && !window.__NEXT_LOAD__) {
     window.__NEXT_LOAD__ = {}
-    update(false)
+    update()
   }
 
   useEffect(update)
-  function update(rerender = true) {
+  function update() {
     const el = document.getElementById('__NEXT_LOAD_DATA__')
     if (!el) return
     const { hydrate, page } = el.dataset
     const shouldRerender = page !== window.__NEXT_LOAD__.page
-    window.__NEXT_LOAD__ = { hydrate, page }
-    if (shouldRerender && rerender) forceUpdate()
+    window.__NEXT_LOAD__ = { hydrate: JSON.parse(hydrate!), page }
+    if (shouldRerender) forceUpdate()
   }
 }
 

--- a/packages/next-load/index.ts
+++ b/packages/next-load/index.ts
@@ -33,3 +33,41 @@ export function _useHydrate() {
     if (shouldRerender && rerender) forceUpdate()
   }
 }
+
+export async function __nl_load(props: any, page: string, config: any) {
+  const keys = Object.keys(config)
+
+  const data = await Promise.all(keys.map(key => {
+    const item = config[key]
+    if (isPageOfTheList(page, item.pages) && typeof item.load === 'function') {
+      return item.load(props)
+    }
+  }))
+
+  return data.reduce((acc, item, index) => {
+    if (item) acc[keys[index]] = item
+    return acc
+  }, {})
+}
+
+export async function __nl_hydrate(props: any, page: string, config: any) {
+  const keys = Object.keys(props)
+
+  const data = await Promise.all(keys.map(key => {
+    const item = config[key]
+    const toHydrate = isPageOfTheList(page, item.pages) && typeof item.hydrate === 'function'
+    return toHydrate ? item.hydrate(props[key]) : props[key]
+  }))
+
+  return data.reduce((acc, item, index) => {
+    if (item) acc[keys[index]] = item
+    return acc
+  }, {})
+}
+
+function isPageOfTheList(page: string, list: (string | RegExp)[] = []) {
+  return list.some((item) => {
+    if (typeof item === 'string') return item === page
+    return item.test(page)
+  })
+}

--- a/packages/next-load/index.ts
+++ b/packages/next-load/index.ts
@@ -34,13 +34,14 @@ export function _useHydrate() {
   }
 }
 
-export async function __nl_load(props: any, page: string, config: any) {
+export async function __nl_load(pageProps: any, page: string, config: any) {
   const keys = Object.keys(config)
 
   const data = await Promise.all(keys.map(key => {
     const item = config[key]
     if (isPageOfTheList(page, item.pages) && typeof item.load === 'function') {
-      return item.load(props, page)
+      // TODO: support { pageProps, layoutProps, loadingProps, templateProps, ... }
+      return item.load({ pageProps }, page)
     }
   }))
 

--- a/packages/next-load/index.ts
+++ b/packages/next-load/index.ts
@@ -40,7 +40,7 @@ export async function __nl_load(props: any, page: string, config: any) {
   const data = await Promise.all(keys.map(key => {
     const item = config[key]
     if (isPageOfTheList(page, item.pages) && typeof item.load === 'function') {
-      return item.load(props)
+      return item.load(props, page)
     }
   }))
 
@@ -56,7 +56,7 @@ export async function __nl_hydrate(props: any, page: string, config: any) {
   const data = await Promise.all(keys.map(key => {
     const item = config[key]
     const toHydrate = isPageOfTheList(page, item.pages) && typeof item.hydrate === 'function'
-    return toHydrate ? item.hydrate(props[key]) : props[key]
+    return toHydrate ? item.hydrate(props[key], page) : props[key]
   }))
 
   return data.reduce((acc, item, index) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1732,9 +1732,9 @@
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
 "@types/node@*":
-  version "18.14.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.14.1.tgz#90dad8476f1e42797c49d6f8b69aaf9f876fc69f"
-  integrity sha512-QH+37Qds3E0eDlReeboBxfHbX9omAcBCXEzswCu6jySP642jiM3cYSIkU/REqwhCUqXdonHFuBfJDiAJxMNhaQ==
+  version "18.14.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.14.2.tgz#c076ed1d7b6095078ad3cf21dfeea951842778b1"
+  integrity sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA==
 
 "@types/node@18.11.18":
   version "18.11.18"
@@ -2618,9 +2618,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001426, caniuse-lite@^1.0.30001449:
-  version "1.0.30001457"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001457.tgz#6af34bb5d720074e2099432aa522c21555a18301"
-  integrity sha512-SDIV6bgE1aVbK6XyxdURbUE89zY7+k1BBBaOwYwkNCglXlel/E7mELiHC64HQ+W0xSKlqWhV9Wh7iHxUjMs4fA==
+  version "1.0.30001458"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001458.tgz#871e35866b4654a7d25eccca86864f411825540c"
+  integrity sha512-lQ1VlUUq5q9ro9X+5gOEyH7i3vm+AYVT1WDCVB69XOZ17KZRhnZ9J0Sqz7wTHQaLBJccNCHq8/Ww5LlOIZbB0w==
 
 chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
@@ -2796,9 +2796,9 @@ convert-source-map@^2.0.0:
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
 core-js-compat@^3.25.1:
-  version "3.28.0"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.28.0.tgz#c08456d854608a7264530a2afa281fadf20ecee6"
-  integrity sha512-myzPgE7QodMg4nnd3K1TDoES/nADRStM8Gpz0D6nhkwbmwEnE0ZGJgoWsvQ722FR8D7xS0n0LV556RcEicjTyg==
+  version "3.29.0"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.29.0.tgz#1b8d9eb4191ab112022e7f6364b99b65ea52f528"
+  integrity sha512-ScMn3uZNAFhK2DGoEfErguoiAHhV2Ju+oJo/jK08p7B3f3UhocUrCCkTvnZaiS+edl5nlIoiBXKcwMc6elv4KQ==
   dependencies:
     browserslist "^4.21.5"
 


### PR DESCRIPTION
Simplify load and hydrate in next.load.ts. This way in the next steps we can manage `load` and `hydrate` not only in pages, also between layouts, route, not-found, etc 😊

The implementation change replaces the use of `load` and `hydrate` at the page level with a single file for all pages, making it easier to use. In addition, the load function now takes two arguments: `{ pageProps }` to provide page properties, and `pathname` to determine the page. For `hydrate`, the first argument is the `data` loaded with `load`, and the second argument is also the page `pathname`. This allows pages that do not need hydration to return `undefined`.

Here's an example of the new configuration:

**next.load.ts**
```ts
import { Post, User } from "./app/types"

export default {
  user: {
    pages: ['/', '/about', '/contact', '/blog/[slug]', new RegExp('^/example')],
    load: getUser,
    hydrate: mapUserDataForClientSide,
  },
  posts: {
    pages: ['/blog/[slug]', '/blog/[slug]/comments'],
    load: getPosts,
  },
}

async function getUser(): Promise<User> {
  return { username: 'aralroca', displayName: 'Aral Roca' }
}

function mapUserDataForClientSide(user: User, pathname: string): User {
  if (pathname !== '/blog/[slug]') return
  return { username: user.username }
}

async function getPosts(): Promise<Post[]> {
  return [{ title: 'My first post', content: 'Hello world!' }]
}
```

The argument `pages` support an `(string | RegExp)[]`.

And the `consume` method is going to return `{ user?: User, posts?: Post[] }`.

**app/blog/[slug]/page.ts**
```ts
import { consume } from 'next-load'

export function Blog() {
  const { user, posts } = consume()
  // ...
}
```